### PR TITLE
支持codex使用cc_switch等本地代理

### DIFF
--- a/docs/zh-CN/runtime-options.md
+++ b/docs/zh-CN/runtime-options.md
@@ -314,6 +314,8 @@ uv run drawai \
 | `DRAWAI_WORKBENCH_FRONTEND_PORT` | 前端端口 |
 | `DRAWAI_WORKBENCH_API_PORT` | Workbench API 端口 |
 | `DRAWAI_WORKBENCH_WORKSPACE` | Workbench 数据目录 |
+| `DRAWAI_CODEX_INHERIT_HOST_CONFIG` | 设为 `1` 时，受控 Codex 子进程继承 host Codex `config.toml` 里的模型 provider/base_url/model 配置 |
+| `DRAWAI_CODEX_MODEL` | 覆盖继承到受控 Codex 子进程的模型名，例如 CCswitch 中可用的 `gpt-5.5` |
 | `OPENAI_API_KEY` | Codex/OpenAI 认证方式之一 |
 | `HF_TOKEN` | Hugging Face 下载 gated repo 时使用 |
 
@@ -371,7 +373,7 @@ uv run drawai run examples/demo_figure.png --local --dry-run
 - 局域网访问失败：服务端用 `--host 0.0.0.0`，客户端用服务器真实 IP，不要用 `127.0.0.1` 或 `0.0.0.0`。
 - 模型服务连不上：先在服务所在机器运行 `curl http://127.0.0.1:18080/health`，再从客户端机器访问 `curl http://<server-ip>:18080/health`。
 - GPU 没生效：确认 setup 时用了 `--device gpu`，并检查 `nvidia-smi` 和 `uv run drawai doctor local`。
-- Codex 认证失败：设置 `OPENAI_API_KEY`，或先完成 Codex 登录，再运行 `uv run drawai doctor local`。
+- Codex 认证失败：设置 `OPENAI_API_KEY`，或先完成 Codex 登录，再运行 `uv run drawai doctor local`。如果 Codex 通过 CCswitch 等本地 provider 代理运行，可设置 `DRAWAI_CODEX_INHERIT_HOST_CONFIG=1` 让 DrawAI 的受控 Codex 子进程继承 host Codex provider 配置；如果继承到的模型不可用，再用 `DRAWAI_CODEX_MODEL` 指定可用模型。
 
 ## 协议提醒
 

--- a/scripts/run_codex_element_analysis.py
+++ b/scripts/run_codex_element_analysis.py
@@ -559,20 +559,9 @@ def image_cli_args(image_paths: Sequence[Path]) -> list[str]:
 
 
 def cli_config_args(reasoning_effort: str, extra_overrides: Sequence[str]) -> list[str]:
-    overrides = [
-        'web_search="disabled"',
-        "features.shell_tool=true",
-        "features.multi_agent=false",
-        "features.memories=false",
-        "features.hooks=false",
-        "features.apps=false",
-        "project_doc_max_bytes=0",
-        "project_doc_fallback_filenames=[]",
-        'cli_auth_credentials_store="file"',
-        f'model_reasoning_effort="{reasoning_effort}"',
-        'sandbox_mode="danger-full-access"',
-        *[str(item) for item in extra_overrides],
-    ]
+    overrides = controlled_codex_config_overrides(
+        [f'model_reasoning_effort="{reasoning_effort}"', *[str(item) for item in extra_overrides]]
+    )
     args: list[str] = []
     for override in overrides:
         args.extend(["-c", override])

--- a/src/drawai/codex_python_sdk_svg.py
+++ b/src/drawai/codex_python_sdk_svg.py
@@ -11,6 +11,7 @@ import shutil
 import tempfile
 import threading
 import time
+import tomllib
 from pathlib import Path
 from typing import Any, Mapping, Sequence
 
@@ -75,7 +76,65 @@ def controlled_codex_config_overrides(
         'shell_environment_policy.exclude=["CODEX_HOME","DRAWAI_HOST_HOME","DRAWAI_HOST_CODEX_HOME"]',
         'sandbox_mode="danger-full-access"',
     )
-    return (*overrides, *(str(item) for item in (extra_overrides or ())))
+    return (
+        *overrides,
+        *_host_codex_model_provider_overrides_from_env(),
+        *(str(item) for item in (extra_overrides or ())),
+    )
+
+
+def _host_codex_model_provider_overrides_from_env() -> tuple[str, ...]:
+    if not _env_truthy(os.environ.get("DRAWAI_CODEX_INHERIT_HOST_CONFIG")):
+        return ()
+    return host_codex_model_provider_overrides(_host_codex_home() / "config.toml")
+
+
+def host_codex_model_provider_overrides(config_path: str | Path) -> tuple[str, ...]:
+    """Return safe model/provider -c overrides from a host Codex config."""
+
+    path = Path(config_path).expanduser().resolve(strict=False)
+    try:
+        payload = tomllib.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        return ()
+    if not isinstance(payload, Mapping):
+        return ()
+
+    provider_name = str(payload.get("model_provider") or "").strip()
+    providers = payload.get("model_providers")
+    if not provider_name or not isinstance(providers, Mapping):
+        return ()
+    provider = providers.get(provider_name)
+    if not isinstance(provider, Mapping):
+        return ()
+
+    overrides: list[str] = [f"model_provider={_toml_string(provider_name)}"]
+    model_name = str(os.environ.get("DRAWAI_CODEX_MODEL") or payload.get("model") or "").strip()
+    if model_name:
+        overrides.append(f"model={_toml_string(model_name)}")
+
+    provider_key = _toml_dotted_key(provider_name)
+    prefix = f"model_providers.{provider_key}"
+    for key in ("name", "wire_api", "base_url", "env_key"):
+        value = provider.get(key)
+        if isinstance(value, str) and value.strip():
+            overrides.append(f"{prefix}.{key}={_toml_string(value.strip())}")
+    requires_auth = provider.get("requires_openai_auth")
+    if isinstance(requires_auth, bool):
+        overrides.append(f"{prefix}.requires_openai_auth={str(requires_auth).lower()}")
+    return tuple(overrides)
+
+
+def _env_truthy(value: str | None) -> bool:
+    return str(value or "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _toml_dotted_key(value: str) -> str:
+    return value if re.fullmatch(r"[A-Za-z0-9_-]+", value) else _toml_string(value)
+
+
+def _toml_string(value: str) -> str:
+    return json.dumps(str(value))
 
 
 def parse_svg_from_final_response(final_response: Any) -> tuple[str, dict[str, str]]:

--- a/tests/semantic_ppt/drawai_pipeline/test_element_analysis_cli_config.py
+++ b/tests/semantic_ppt/drawai_pipeline/test_element_analysis_cli_config.py
@@ -1,0 +1,29 @@
+from scripts import run_codex_element_analysis
+
+
+def test_cli_config_args_can_inherit_host_codex_model_provider(monkeypatch, tmp_path):
+    host_codex_home = tmp_path / "host_codex"
+    host_codex_home.mkdir()
+    (host_codex_home / "config.toml").write_text(
+        """
+model_provider = "custom"
+model = "gpt-5.5"
+
+[model_providers.custom]
+name = "custom"
+wire_api = "responses"
+requires_openai_auth = true
+base_url = "http://127.0.0.1:15721/v1"
+""",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("DRAWAI_HOST_CODEX_HOME", str(host_codex_home))
+    monkeypatch.setenv("DRAWAI_CODEX_INHERIT_HOST_CONFIG", "1")
+
+    args = run_codex_element_analysis.cli_config_args("medium", [])
+    overrides = [args[index + 1] for index, value in enumerate(args) if value == "-c"]
+
+    assert 'model_provider="custom"' in overrides
+    assert 'model="gpt-5.5"' in overrides
+    assert 'model_providers.custom.base_url="http://127.0.0.1:15721/v1"' in overrides
+    assert 'model_reasoning_effort="medium"' in overrides

--- a/tests/semantic_ppt/drawai_pipeline/test_python_sdk_svg_adapter.py
+++ b/tests/semantic_ppt/drawai_pipeline/test_python_sdk_svg_adapter.py
@@ -44,6 +44,60 @@ def test_controlled_codex_config_overrides_disable_agent_surfaces():
     assert 'shell_environment_policy.exclude=["CODEX_HOME","DRAWAI_HOST_HOME","DRAWAI_HOST_CODEX_HOME"]' in overrides
 
 
+def test_controlled_codex_config_overrides_can_inherit_host_model_provider(monkeypatch, tmp_path):
+    host_codex_home = tmp_path / "host_codex"
+    host_codex_home.mkdir()
+    (host_codex_home / "config.toml").write_text(
+        """
+model_provider = "custom"
+model = "gpt-5.5"
+
+[model_providers.custom]
+name = "custom"
+wire_api = "responses"
+requires_openai_auth = true
+base_url = "http://127.0.0.1:15721/v1"
+""",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("DRAWAI_HOST_CODEX_HOME", str(host_codex_home))
+    monkeypatch.setenv("DRAWAI_CODEX_INHERIT_HOST_CONFIG", "1")
+
+    overrides = controlled_codex_config_overrides()
+
+    assert 'model_provider="custom"' in overrides
+    assert 'model="gpt-5.5"' in overrides
+    assert 'model_providers.custom.name="custom"' in overrides
+    assert 'model_providers.custom.wire_api="responses"' in overrides
+    assert "model_providers.custom.requires_openai_auth=true" in overrides
+    assert 'model_providers.custom.base_url="http://127.0.0.1:15721/v1"' in overrides
+
+
+def test_controlled_codex_config_overrides_allows_model_env_override(monkeypatch, tmp_path):
+    host_codex_home = tmp_path / "host_codex"
+    host_codex_home.mkdir()
+    (host_codex_home / "config.toml").write_text(
+        """
+model_provider = "custom"
+model = "gpt-5.4"
+
+[model_providers.custom]
+name = "custom"
+wire_api = "responses"
+base_url = "http://127.0.0.1:15721/v1"
+""",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("DRAWAI_HOST_CODEX_HOME", str(host_codex_home))
+    monkeypatch.setenv("DRAWAI_CODEX_INHERIT_HOST_CONFIG", "1")
+    monkeypatch.setenv("DRAWAI_CODEX_MODEL", "gpt-5.5")
+
+    overrides = controlled_codex_config_overrides()
+
+    assert 'model="gpt-5.5"' in overrides
+    assert 'model="gpt-5.4"' not in overrides
+
+
 def test_isolated_codex_home_copies_auth_without_global_agents(monkeypatch, tmp_path):
     host_codex_home = tmp_path / "host_codex"
     host_codex_home.mkdir()


### PR DESCRIPTION
This pull request introduces a mechanism for DrawAI to inherit model provider and model configuration from a host Codex instance by reading its `config.toml`, controlled via new environment variables. It also updates documentation to describe these options, refactors CLI argument construction to support the new inheritance logic, and adds comprehensive tests to ensure correct behavior and environment override support.

Configuration inheritance and CLI overrides:

* Added support for DrawAI-controlled Codex subprocesses to inherit model provider and model configuration from the host's Codex `config.toml` when `DRAWAI_CODEX_INHERIT_HOST_CONFIG=1` is set; allows overriding the inherited model with `DRAWAI_CODEX_MODEL`. The logic for extracting and formatting these overrides is implemented in `src/drawai/codex_python_sdk_svg.py`.
* Refactored `cli_config_args` in `scripts/run_codex_element_analysis.py` to use the new inheritance-aware override generator, ensuring CLI invocations include the correct configuration.

Documentation updates:

* Updated `docs/zh-CN/runtime-options.md` to document the new environment variables `DRAWAI_CODEX_INHERIT_HOST_CONFIG` and `DRAWAI_CODEX_MODEL`, and added troubleshooting guidance for Codex authentication and model selection in proxy/CCswitch scenarios. [[1]](diffhunk://#diff-11431861d6860ed87025373c1b7ac83b3292c7078523d04b4b9ce41ea2cb0851R317-R318) [[2]](diffhunk://#diff-11431861d6860ed87025373c1b7ac83b3292c7078523d04b4b9ce41ea2cb0851L374-R376)

Testing enhancements:

* Added tests in `tests/semantic_ppt/drawai_pipeline/test_python_sdk_svg_adapter.py` and `test_element_analysis_cli_config.py` to verify that configuration inheritance and environment variable overrides work as intended, including edge cases for model name precedence. [[1]](diffhunk://#diff-9f7995616b1be6a7b8c9a3e885bafbac13be6c81018f5c3a53a6f83ad2c5b40cR47-R100) [[2]](diffhunk://#diff-aab84638fa7baf98be9a9b96caef3a52327b59baeab9521ca0961b7dd2196975R1-R29)

Dependency update:

* Imported `tomllib` in `src/drawai/codex_python_sdk_svg.py` for TOML parsing, enabling reading of host Codex configuration files.